### PR TITLE
Address deprecated ModelCardCallback from sentence_transformers

### DIFF
--- a/src/setfit/trainer.py
+++ b/src/setfit/trainer.py
@@ -7,7 +7,8 @@ from datasets import Dataset, DatasetDict
 from packaging.version import parse as parse_version
 from sentence_transformers import SentenceTransformerTrainer, losses
 from sentence_transformers.losses.BatchHardTripletLoss import BatchHardTripletLossDistanceFunction
-from sentence_transformers.model_card import ModelCardCallback as STModelCardCallback
+from sentence_transformers.model_card import ModelCardCallback as DeprecatedSTModelCardCallback
+from sentence_transformers.model_card import SentenceTransformerModelCardCallback
 from sentence_transformers.training_args import BatchSamplers, SentenceTransformerTrainingArguments
 from sklearn.preprocessing import LabelEncoder
 from torch import nn
@@ -58,7 +59,7 @@ class BCSentenceTransformersTrainer(SentenceTransformerTrainer):
             if isinstance(callback, CodeCarbonCallback):
                 self.setfit_model.model_card_data.code_carbon_callback = callback
 
-            if isinstance(callback, STModelCardCallback):
+            if isinstance(callback, (DeprecatedSTModelCardCallback, SentenceTransformerModelCardCallback)):
                 self.remove_callback(callback)
 
         if is_in_notebook():


### PR DESCRIPTION
Addresses a minor issue related to the deprecation of `sentence_transformers.model_card.ModelCardCallback`. This has since been changed to `sentence_transformers.model_card.SentenceTransformerModelCardCallback` and the PR will catch either object type.

I initially encounted a bug when I had `setfit==1.1.1` with `sentence-transformers==4.1.0` (which resulted from an "unversioned" mamba-based build). Prior to #595 (as is the case for v1.1.1), there was an instance of `sentence_transformers.model_card.SentenceTransformerModelCardCallback` which was added by the `add_model_card_callback` method in the `sentence_transformers.SentenceTransformerTrainer` class. Since the object type did not match `sentence_transformers.model_card.ModelCardCallback` (aliased as `STModelCardCallback` in `setfit/trainer.py`), the callback was *not* removed and a call to the `setfit.Trainer` constructor resulted in this:
```
TypeError: SentenceTransformerModelCardCallback.on_init_end() missing 1 required positional argument: 'trainer'
```

Note that this is no longer an issue with `setfit==1.1.2`, yet this PR addresses the potential where either the current or deprecated callback makes its way into `setfit.trainer.BCSentenceTransformersTrainer` 