### PR TITLE
Support huggingface_hub v0.x and v1.x

### DIFF
--- a/src/setfit/modeling.py
+++ b/src/setfit/modeling.py
@@ -7,10 +7,9 @@ from typing import Dict, List, Literal, Optional, Set, Tuple, Union
 
 import joblib
 import numpy as np
-import requests
 import torch
 from huggingface_hub import ModelHubMixin, hf_hub_download
-from huggingface_hub.utils import validate_hf_hub_args
+from huggingface_hub.utils import validate_hf_hub_args, HfHubHTTPError
 from packaging.version import Version, parse
 from sentence_transformers import SentenceTransformer
 from sentence_transformers import __version__ as sentence_transformers_version
@@ -774,7 +773,7 @@ class SetFitModel(ModelHubMixin):
                     token=token,
                     local_files_only=local_files_only,
                 )
-            except requests.exceptions.RequestException:
+            except HfHubHTTPError:
                 pass
 
         model_kwargs = {key: value for key, value in model_kwargs.items() if value is not None}
@@ -816,7 +815,7 @@ class SetFitModel(ModelHubMixin):
                     token=token,
                     local_files_only=local_files_only,
                 )
-            except requests.exceptions.RequestException:
+            except HfHubHTTPError:
                 logger.info(
                     f"{MODEL_HEAD_NAME} not found on HuggingFace Hub, initialising classification head with random weights."
                     " You should TRAIN this model on a downstream task to use it for predictions and inference."

--- a/src/setfit/modeling.py
+++ b/src/setfit/modeling.py
@@ -9,7 +9,7 @@ import joblib
 import numpy as np
 import torch
 from huggingface_hub import ModelHubMixin, hf_hub_download
-from huggingface_hub.utils import validate_hf_hub_args, HfHubHTTPError
+from huggingface_hub.utils import HfHubHTTPError, validate_hf_hub_args
 from packaging.version import Version, parse
 from sentence_transformers import SentenceTransformer
 from sentence_transformers import __version__ as sentence_transformers_version


### PR DESCRIPTION
Related to https://github.com/huggingface/huggingface_hub/issues/3340.

This PR adapts SetFit to be compatible with both huggingface_hub v0.x and v1.x. 

In practice nothing else should change (I've checked the codebase). The `HfHubHTTPError` is a base error defined in `huggingface_hub` that inherits from `requests.HTTPError` in v0.x and will inherit from `httpx.HTTPError` in v1.x. It has been introduced ~2 years ago so it's fine to use it right now (i.e. no need to wait for v1.x release or bump minimal version)