### PR TITLE
Harden summary table tar extraction

### DIFF
--- a/scripts/create_summary_table.py
+++ b/scripts/create_summary_table.py
@@ -6,6 +6,7 @@ from collections import defaultdict
 from glob import glob
 from os import listdir
 from os.path import isdir, join, splitext
+from pathlib import Path, PureWindowsPath
 from typing import List, Tuple
 
 from numpy import mean, median, std
@@ -28,11 +29,34 @@ TEST_DATASET_TO_METRIC = {
 }
 
 
-def extract_results(path: str) -> None:
-    tar = tarfile.open(path, "r:gz")
+def _validate_tar_member(member: tarfile.TarInfo, extraction_dir: Path) -> None:
+    member_path = Path(member.name)
+    windows_member_path = PureWindowsPath(member.name)
+
+    if member_path.is_absolute() or windows_member_path.is_absolute() or windows_member_path.drive:
+        raise ValueError(f"Unsafe path in tar archive: {member.name}")
+    if ".." in member_path.parts or ".." in windows_member_path.parts:
+        raise ValueError(f"Unsafe path in tar archive: {member.name}")
+    if not (member.isfile() or member.isdir()):
+        raise ValueError(f"Unsupported member type in tar archive: {member.name}")
+
+    target_path = (extraction_dir / member.name).resolve()
+    if extraction_dir not in [target_path, *target_path.parents]:
+        raise ValueError(f"Unsafe path in tar archive: {member.name}")
+
+
+def extract_results(path: str) -> str:
     unzip_path = splitext(splitext(path)[-2])[-2]
-    tar.extractall(path=os.path.dirname(unzip_path))
-    tar.close()
+    extraction_dir = Path(os.path.dirname(unzip_path)).resolve()
+
+    with tarfile.open(path, "r:gz") as tar:
+        for member in tar.getmembers():
+            _validate_tar_member(member, extraction_dir)
+        try:
+            tar.extractall(path=extraction_dir, filter="data")
+        except TypeError:
+            tar.extractall(path=extraction_dir)
+
     return unzip_path
 
 

--- a/tests/test_create_summary_table.py
+++ b/tests/test_create_summary_table.py
@@ -1,0 +1,46 @@
+import importlib.util
+import io
+import tarfile
+from pathlib import Path
+
+import pytest
+
+
+def load_create_summary_table_module():
+    script_path = Path(__file__).resolve().parents[1] / "scripts" / "create_summary_table.py"
+    spec = importlib.util.spec_from_file_location("create_summary_table", script_path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+create_summary_table = load_create_summary_table_module()
+
+
+def write_tar_member(archive_path, member_name, payload=b"contents"):
+    with tarfile.open(archive_path, "w:gz") as tar:
+        member = tarfile.TarInfo(member_name)
+        member.size = len(payload)
+        tar.addfile(member, io.BytesIO(payload))
+
+
+def test_extract_results_rejects_members_outside_extraction_directory(tmp_path):
+    sandbox = tmp_path / "sandbox"
+    sandbox.mkdir()
+    archive_path = sandbox / "results.tar.gz"
+    write_tar_member(archive_path, "../escaped.txt")
+
+    with pytest.raises(ValueError, match="Unsafe path"):
+        create_summary_table.extract_results(str(archive_path))
+
+    assert not (tmp_path / "escaped.txt").exists()
+
+
+def test_extract_results_extracts_safe_archive_members(tmp_path):
+    archive_path = tmp_path / "results.tar.gz"
+    write_tar_member(archive_path, "results/dataset/train-8-0/results.json", b'{"score": 95}')
+
+    extracted_path = create_summary_table.extract_results(str(archive_path))
+
+    assert extracted_path == str(tmp_path / "results")
+    assert (tmp_path / "results" / "dataset" / "train-8-0" / "results.json").read_bytes() == b'{"score": 95}'


### PR DESCRIPTION
## Summary
- Validate tar members before extracting summary-table result archives.
- Reject absolute paths, parent-directory traversal, drive-qualified Windows paths, and non-file/directory members.
- Add focused tests for unsafe and safe archive members.

## Validation
- `uv run --no-project --with pytest --with numpy --with scipy pytest -q --noconftest -o addopts='' tests/test_create_summary_table.py`
- `uv run --no-project --with flake8 flake8 scripts/create_summary_table.py tests/test_create_summary_table.py`
- `python3 -m py_compile scripts/create_summary_table.py tests/test_create_summary_table.py`