### PR TITLE
fix: honor report_to when constructing the internal ST trainer

### DIFF
--- a/src/setfit/trainer.py
+++ b/src/setfit/trainer.py
@@ -49,7 +49,11 @@ class BCSentenceTransformersTrainer(SentenceTransformerTrainer):
         self.logs_prefix = "embedding"
         super().__init__(
             model=setfit_model.model_body,
-            args=SentenceTransformerTrainingArguments(output_dir=setfit_args.output_dir),
+            # `report_to` must be set before the superclass initializes the reporting callbacks, otherwise
+            # integrations that the user excluded are still loaded and executed.
+            args=SentenceTransformerTrainingArguments(
+                output_dir=setfit_args.output_dir, report_to=setfit_args.report_to
+            ),
             **kwargs,
         )
         self._apply_training_arguments(setfit_args)

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -558,6 +558,7 @@ def test_trainer_callbacks(model: SetFitModel):
 
 
 def test_trainer_report_to(model: SetFitModel, monkeypatch: pytest.MonkeyPatch):
+    # Issue #621: integrations that were not requested via `report_to` must not be loaded
     class DummyReportCallback(TrainerCallback):
         pass
 

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -8,11 +8,11 @@ import pytest
 import torch
 from datasets import Dataset, load_dataset
 from sentence_transformers import losses
-from transformers import TrainerCallback
+from transformers import TrainerCallback, integrations
 from transformers.testing_utils import require_optuna
 from transformers.utils.hp_naming import TrialShortNamer
 
-from setfit import logging
+from setfit import logging, training_args
 from setfit.losses import SupConLoss
 from setfit.modeling import SetFitModel
 from setfit.trainer import Trainer
@@ -555,6 +555,24 @@ def test_trainer_callbacks(model: SetFitModel):
     assert trainer.st_trainer.callback_handler.callbacks[-1] == callback
     trainer.remove_callback(callback)
     assert callback not in trainer.st_trainer.callback_handler.callbacks
+
+
+def test_trainer_report_to(model: SetFitModel, monkeypatch: pytest.MonkeyPatch):
+    class DummyReportCallback(TrainerCallback):
+        pass
+
+    monkeypatch.setattr(training_args, "get_available_reporting_integrations", lambda: ["dummy"])
+    monkeypatch.setitem(integrations.INTEGRATION_TO_CALLBACK, "dummy", DummyReportCallback)
+
+    def reports_to_dummy(args: TrainingArguments) -> bool:
+        trainer = Trainer(model=model, args=args)
+        return any(
+            isinstance(callback, DummyReportCallback) for callback in trainer.st_trainer.callback_handler.callbacks
+        )
+
+    assert reports_to_dummy(TrainingArguments(report_to="all"))
+    assert reports_to_dummy(TrainingArguments(report_to="dummy"))
+    assert not reports_to_dummy(TrainingArguments(report_to="none"))
 
 
 def test_trainer_warn_freeze(model: SetFitModel):


### PR DESCRIPTION
## Summary
`BCSentenceTransformersTrainer` built `SentenceTransformerTrainingArguments` with only `output_dir`, so `report_to` defaulted to `"all"`. `transformers.Trainer.__init__` registered every installed integration (including DagsHub) before `_apply_training_arguments` copied the user's `report_to`.

On Windows, `DagsHubCallback.setup` then splits `MLFLOW_TRACKING_URI` on `os.sep` and crashes even when the user asked for `report_to="mlflow"` (or `"none"`).

Pass `report_to` at construction time so callbacks match the user's setting.

Closes #621

## Test plan
- [x] `pytest tests/test_trainer.py tests/test_training_args.py tests/test_model_card.py -q` → 50 passed, 2 skipped
- [x] New `test_trainer_report_to` fails on current main (`report_to="none"` still registers a dummy integration) and passes after the change