### PR TITLE
Introduce compatibility with transformers v5, Sentence Transformers v6 and huggingface_hub v1

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,7 @@ on:
 
 env:
   TRANSFORMERS_IS_CI: 1
+  HF_HUB_DISABLE_PROGRESS_BARS: 1  # The Transformers v5 weight loading progress bars heavily expand the logs
   HF_TOKEN: ${{ secrets.HF_TOKEN }}  # Read token to avoid rate limits when downloading from the Hub
 
 jobs:
@@ -51,56 +52,14 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
 
-      # Taken from https://github.com/actions/cache?tab=readme-ov-file#creating-a-cache-key
-      # Use date to invalidate cache every week
-      - name: Get date
-        id: get-date
-        run: |
-          echo "date=$(/bin/date -u "+%G%V")" >> $GITHUB_OUTPUT
-        shell: bash
+      - name: Install uv
+        uses: astral-sh/setup-uv@20cfd1bf945f4377ade1205e4dbc17946fc9a30d  # v10.0.1
 
-      - name: Try to load cached dependencies
-        uses: actions/cache@6f8efc29b200d32929f49075959781ed54ec270c  # v3
-        id: restore-cache
-        with:
-          path: ${{ env.pythonLocation }}
-          key: python-dependencies-${{ matrix.os }}-${{ steps.get-date.outputs.date }}-${{ matrix.python-version }}-${{ matrix.requirements }}-${{ hashFiles('setup.py') }}-${{ env.pythonLocation }}
-
-      - name: Install external dependencies on cache miss
+      - name: Install dependencies
         run: |
-          python -m pip install --no-cache-dir --upgrade pip
-          python -m pip install --no-cache-dir ${{ matrix.requirements }}
-          python -m pip install '.[codecarbon]'
+          uv pip install '${{ matrix.requirements }}' '.[codecarbon]' --system
           python -m spacy download en_core_web_lg
           python -m spacy download en_core_web_sm
-        if: steps.restore-cache.outputs.cache-hit != 'true'
 
-      - name: Install the checked-out setfit
-        run: python -m pip install .
-
-      - name: Restore HF models from cache
-        uses: actions/cache/restore@6f8efc29b200d32929f49075959781ed54ec270c  # v3
-        with:
-          path: |
-            ~/.cache/huggingface/hub
-            ~/.cache/torch
-          key: hf-models-${{ matrix.os }}-${{ env.NEW_HF_CACHE_HASH }}
-          restore-keys: |
-            hf-models-${{ matrix.os }}-
-      
       - name: Run unit tests
-        shell: bash
-        run: |
-          echo "OLD_HF_CACHE_HASH=$(find ~/.cache/huggingface/hub ~/.cache/torch -type f -exec sha256sum {} + | LC_ALL=C sort | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_ENV
-          pytest -v tests/
-          echo "NEW_HF_CACHE_HASH=$(find ~/.cache/huggingface/hub ~/.cache/torch -type f -exec sha256sum {} + | LC_ALL=C sort | sha256sum | cut -d ' ' -f 1)" >> $GITHUB_ENV
-
-      - name: Save new HF models to cache
-        uses: actions/cache/save@6f8efc29b200d32929f49075959781ed54ec270c  # v3
-        with:
-          path: |
-            ~/.cache/huggingface/hub
-            ~/.cache/torch
-          key: hf-models-${{ matrix.os }}-${{ env.NEW_HF_CACHE_HASH }}
-        # Only save cache if the hash has changed
-        if: env.NEW_HF_CACHE_HASH != env.OLD_HF_CACHE_HASH
+        run: python -m pytest -v tests/

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -14,6 +14,7 @@ on:
 
 env:
   TRANSFORMERS_IS_CI: 1
+  HF_TOKEN: ${{ secrets.HF_TOKEN }}  # Read token to avoid rate limits when downloading from the Hub
 
 jobs:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,9 +21,24 @@ jobs:
     name: Run unit tests
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
         os: [ubuntu-latest, windows-latest]
-        requirements: ['.[tests]', '.[compat_tests]']
+        requirements: ['.[tests]']
+        include:
+          # The oldest supported dependency versions, pinned in setup.py
+          - python-version: '3.9'
+            os: ubuntu-latest
+            requirements: '.[compat_tests]'
+          - python-version: '3.9'
+            os: windows-latest
+            requirements: '.[compat_tests]'
+          # The last dependency generation before transformers v5
+          - python-version: '3.11'
+            os: ubuntu-latest
+            requirements: '.[compat_tests_v4]'
+          - python-version: '3.11'
+            os: windows-latest
+            requirements: '.[compat_tests_v4]'
       fail-fast: false
     runs-on: ${{ matrix.os }}
     steps:

--- a/setup.py
+++ b/setup.py
@@ -14,20 +14,29 @@ REQUIRED_PKGS = [
     "datasets>=2.15.0",
     "sentence-transformers[train]>=3",
     "transformers>=4.41.0",
-    "evaluate>=0.3.0",
+    # evaluate < 0.4.6 breaks metric loading with huggingface_hub v1.0
+    "evaluate>=0.4.6",
     "huggingface_hub>=0.24.0",
     "scikit-learn",
     "packaging",
 ]
-ABSA_REQUIRE = ["spacy<3.7.6"]
+# spaCy 3.8 depends on blis releases without Python 3.9 wheels, and the spaCy 3.7 binaries need numpy 1.x
+ABSA_REQUIRE = [
+    "spacy<3.8; python_version < '3.10'",
+    "numpy<2; python_version < '3.10'",
+    "spacy; python_version >= '3.10'",
+]
 QUALITY_REQUIRE = ["black", "flake8", "isort", "tabulate"]
-ONNX_REQUIRE = ["onnxruntime", "onnx!=1.16.2", "skl2onnx"]
+# The Python 3.9 wheels of onnx 1.17 to 1.19 crash on Windows once pyarrow.dataset has been imported
+ONNX_REQUIRE = ["onnxruntime", "onnx!=1.16.2", "onnx<1.17; python_version < '3.10'", "skl2onnx"]
+# hummingbird-ml pins onnx<=1.16.1, which has no wheels for Python 3.13
 OPENVINO_REQUIRE = ["hummingbird-ml", "openvino"]
-TESTS_REQUIRE = ["pytest", "pytest-cov"] + ONNX_REQUIRE + OPENVINO_REQUIRE + ABSA_REQUIRE
+TESTS_REQUIRE = ["pytest", "pytest-cov"] + ONNX_REQUIRE + ABSA_REQUIRE
 DOCS_REQUIRE = ["hf-doc-builder>=0.3.0"]
-CODECARBON_REQUIRE = ["codecarbon<2.6.0"]
-# 2.7.* fails with AttributeError: 'EmissionsTracker' object has no attribute '_cloud'
 # 2.6.* has an accidental print statement spamming the terminal
+# 2.7.* and 2.8.* lock out a second EmissionsTracker in the same process (allow_multiple_runs only
+# defaults to True from 3.0.0), and the locked-out tracker then fails with a missing _cloud
+CODECARBON_REQUIRE = ["codecarbon!=2.6.*,!=2.7.*,!=2.8.*"]
 EXTRAS_REQUIRE = {
     "optuna": INTEGRATIONS_REQUIRE,
     "quality": QUALITY_REQUIRE,
@@ -48,12 +57,20 @@ EXTRAS_REQUIRE["dev"] = combine_requirements([k for k in EXTRAS_REQUIRE])
 # For the combatibility tests we add pandas<2, as pandas 2.0.0 onwards is incompatible with old datasets versions,
 # and we assume few to no users would use old datasets versions with new pandas versions.
 # The only alternative is incrementing the minimum version for datasets, which seems unnecessary.
-# Beyond that, fsspec is set to <2023.12.0 as that version is incompatible with datasets<=2.15.0
+# Beyond that, fsspec is set to <2023.12.0 as that version is incompatible with datasets<=2.15.0,
+# and numpy<2 as pandas<2 cannot be imported with numpy 2.
 EXTRAS_REQUIRE["compat_tests"] = (
     [requirement.replace(">=", "==") for requirement in REQUIRED_PKGS]
     + TESTS_REQUIRE
-    + ["pandas<2", "fsspec<2023.12.0"]
+    + ["pandas<2", "fsspec<2023.12.0", "numpy<2"]
 )
+# The last dependency generation before transformers v5, huggingface_hub v1 and Sentence Transformers v6
+EXTRAS_REQUIRE["compat_tests_v4"] = TESTS_REQUIRE + [
+    "transformers<5",
+    "sentence-transformers[train]<6",
+    "huggingface_hub<1",
+    "datasets<5",
+]
 
 setup(
     name="setfit",
@@ -83,8 +100,10 @@ setup(
         "Programming Language :: Python :: 3.10",
         "Programming Language :: Python :: 3.11",
         "Programming Language :: Python :: 3.12",
+        "Programming Language :: Python :: 3.13",
         "Topic :: Scientific/Engineering :: Artificial Intelligence",
     ],
+    python_requires=">=3.9",
     keywords="nlp, machine learning, fewshot learning, transformers",
     zip_safe=False,  # Required for mypy to find the py.typed file
 )

--- a/src/setfit/compat.py
+++ b/src/setfit/compat.py
@@ -1,0 +1,44 @@
+"""Imports that differ between the supported versions of transformers and Sentence Transformers."""
+
+from packaging.version import Version, parse
+from sentence_transformers import __version__ as _sentence_transformers_version
+from transformers import __version__ as _transformers_version
+
+
+TRANSFORMERS_VERSION: Version = parse(_transformers_version)
+SENTENCE_TRANSFORMERS_VERSION: Version = parse(_sentence_transformers_version)
+
+# Sentence Transformers v5.4 moved these modules and deprecated the old import paths
+try:
+    from sentence_transformers.sentence_transformer import losses
+    from sentence_transformers.sentence_transformer.model_card import SentenceTransformerModelCardCallback
+    from sentence_transformers.sentence_transformer.modules import Dense
+    from sentence_transformers.sentence_transformer.training_args import BatchSamplers
+except ImportError:
+    from sentence_transformers import losses
+    from sentence_transformers.models import Dense
+    from sentence_transformers.training_args import BatchSamplers
+
+    try:
+        from sentence_transformers.model_card import SentenceTransformerModelCardCallback
+    except ImportError:
+        # Sentence Transformers < 4.0
+        from sentence_transformers.model_card import ModelCardCallback as SentenceTransformerModelCardCallback
+
+# transformers v5 moved default_logdir
+try:
+    from transformers.integrations.integration_utils import default_logdir
+except ImportError:
+    from transformers.training_args import default_logdir
+
+
+__all__ = [
+    "BatchSamplers",
+    "Dense",
+    "SENTENCE_TRANSFORMERS_VERSION",
+    "SentenceTransformerModelCardCallback",
+    "TRANSFORMERS_VERSION",
+    "Version",
+    "default_logdir",
+    "losses",
+]

--- a/src/setfit/exporters/onnx.py
+++ b/src/setfit/exporters/onnx.py
@@ -1,14 +1,15 @@
 import copy
+import inspect
 import warnings
 from typing import Callable, Optional, Union
 
-import numpy as np
 import onnx
 import torch
-from sentence_transformers import SentenceTransformer, models
+from sentence_transformers import SentenceTransformer
 from sklearn.linear_model import LogisticRegression
 from transformers.modeling_utils import PreTrainedModel
 
+from setfit.compat import Dense
 from setfit.exporters.utils import mean_pooling
 
 
@@ -91,6 +92,11 @@ def export_onnx_setfit_model(setfit_model: OnnxSetFitModel, inputs, output_path,
     target = setfit_model.model_body.device
     args = tuple(value.to(target) for value in inputs.values())
 
+    # torch v2.9 made the dynamo based exporter the default, which does not support the opsets used here
+    export_kwargs = {}
+    if "dynamo" in inspect.signature(torch.onnx.export).parameters:
+        export_kwargs["dynamo"] = False
+
     setfit_model.eval()
     with torch.no_grad():
         torch.onnx.export(
@@ -101,6 +107,7 @@ def export_onnx_setfit_model(setfit_model: OnnxSetFitModel, inputs, output_path,
             input_names=["input_ids", "attention_mask", "token_type_ids"],
             output_names=output_names,
             dynamic_axes={**dynamic_axes_input, **dynamic_axes_output},
+            **export_kwargs,
         )
 
 
@@ -123,11 +130,8 @@ def export_sklearn_head_to_onnx(model_head: LogisticRegression, opset: int) -> o
 
     # Check if skl2onnx is installed
     try:
-        import onnxconverter_common
         from skl2onnx import convert_sklearn
-        from skl2onnx.common.data_types import guess_data_type
-        from skl2onnx.sklapi import CastTransformer
-        from sklearn.pipeline import Pipeline
+        from skl2onnx.common.data_types import FloatTensorType
     except ImportError:
         msg = """
         `skl2onnx` must be installed in order to convert a model with an sklearn head.
@@ -135,35 +139,25 @@ def export_sklearn_head_to_onnx(model_head: LogisticRegression, opset: int) -> o
         """
         raise ImportError(msg)
 
-    # Determine the initial type and the shape of the output.
-    input_shape = (None, model_head.n_features_in_)
-    if hasattr(model_head, "coef_"):
-        dtype = guess_data_type(model_head.coef_, shape=input_shape)[0][1]
-    elif not hasattr(model_head, "coef_") and hasattr(model_head, "estimators_"):
-        if any([not hasattr(e, "coef_") for e in model_head.estimators_]):
+    # Verify that the head is a linear model, which is all that this conversion supports
+    if not hasattr(model_head, "coef_"):
+        if not hasattr(model_head, "estimators_"):
+            raise ValueError(
+                "The model_head either does not have a coef_ attribute or some estimators in model_head.estimators_ do not have a coef_ attribute. Conversion to ONNX only supports these cases."
+            )
+        if any(not hasattr(e, "coef_") for e in model_head.estimators_):
             raise ValueError(
                 "The model_head is a meta-estimator but not all of the estimators have a coef_ attribute."
             )
-        dtype = guess_data_type(model_head.estimators_[0].coef_, shape=input_shape)[0][1]
-    else:
-        raise ValueError(
-            "The model_head either does not have a coef_ attribute or some estimators in model_head.estimators_ do not have a coef_ attribute. Conversion to ONNX only supports these cases."
-        )
-    dtype.shape = input_shape
 
-    # If the datatype of the model is double we need to cast the outputs
-    # from the setfit model to doubles for compatibility inside of ONNX.
-    if isinstance(dtype, onnxconverter_common.data_types.DoubleTensorType):
-        sklearn_model = Pipeline([("castdouble", CastTransformer(dtype=np.double)), ("head", model_head)])
-    else:
-        sklearn_model = model_head
-
-    # Convert sklearn head into ONNX format
+    # The model body always produces float32 embeddings, so the head is converted to accept those.
+    # skl2onnx casts double coefficients to float32 accordingly.
+    input_shape = (None, model_head.n_features_in_)
     onnx_model = convert_sklearn(
-        sklearn_model,
-        initial_types=[("model_head", dtype)],
+        model_head,
+        initial_types=[("model_head", FloatTensorType(input_shape))],
         target_opset=opset,
-        options={id(sklearn_model): {"zipmap": False}},
+        options={id(model_head): {"zipmap": False}},
     )
 
     return onnx_model
@@ -226,7 +220,7 @@ def export_onnx(
     dummy_inputs = tokenizer(dummy_sample, **tokenizer_kwargs)
 
     # Check to see if the model uses a sklearn head or a torch dense layer.
-    if issubclass(type(model_head), models.Dense):
+    if isinstance(model_head, Dense):
         setfit_model = OnnxSetFitModel(transformer, lambda x: model_pooler(x)["sentence_embedding"], model_head).cpu()
         export_onnx_setfit_model(setfit_model, dummy_inputs, output_path, opset)
 

--- a/src/setfit/exporters/openvino.py
+++ b/src/setfit/exporters/openvino.py
@@ -1,9 +1,14 @@
 import os
 
-import openvino.runtime as ov
+import openvino as ov
 
 from setfit import SetFitModel
 from setfit.exporters.onnx import export_onnx
+
+
+# openvino.runtime was removed in openvino 2026, but older versions only expose the runtime API there
+if not hasattr(ov, "Core"):
+    import openvino.runtime as ov
 
 
 def export_to_openvino(

--- a/src/setfit/model_card.py
+++ b/src/setfit/model_card.py
@@ -517,19 +517,24 @@ class SetFitModelCardData(CardData):
         ).replace("-:|", "--|")
         super_dict["metrics_table"] = make_markdown_table(self.metric_lines).replace("-:|", "--|")
         if self.code_carbon_callback and self.code_carbon_callback.tracker:
-            emissions_data = self.code_carbon_callback.tracker._prepare_emissions_data()
-            super_dict["co2_eq_emissions"] = {
-                # * 1000 to convert kg to g
-                "emissions": float(emissions_data.emissions) * 1000,
-                "source": "codecarbon",
-                "training_type": "fine-tuning",
-                "on_cloud": emissions_data.on_cloud == "Y",
-                "cpu_model": emissions_data.cpu_model,
-                "ram_total_size": emissions_data.ram_total_size,
-                "hours_used": round(emissions_data.duration / 3600, 3),
-            }
-            if emissions_data.gpu_model:
-                super_dict["co2_eq_emissions"]["hardware_used"] = emissions_data.gpu_model
+            try:
+                emissions_data = self.code_carbon_callback.tracker._prepare_emissions_data()
+            except Exception:
+                # codecarbon v3 cannot report emissions before the tracker has been started
+                emissions_data = None
+            if emissions_data is not None:
+                super_dict["co2_eq_emissions"] = {
+                    # * 1000 to convert kg to g
+                    "emissions": float(emissions_data.emissions) * 1000,
+                    "source": "codecarbon",
+                    "training_type": "fine-tuning",
+                    "on_cloud": emissions_data.on_cloud == "Y",
+                    "cpu_model": emissions_data.cpu_model,
+                    "ram_total_size": emissions_data.ram_total_size,
+                    "hours_used": round(emissions_data.duration / 3600, 3),
+                }
+                if emissions_data.gpu_model:
+                    super_dict["co2_eq_emissions"]["hardware_used"] = emissions_data.gpu_model
         if self.dataset_id:
             super_dict["datasets"] = [self.dataset_id]
         if self.st_id:

--- a/src/setfit/modeling.py
+++ b/src/setfit/modeling.py
@@ -7,14 +7,12 @@ from typing import Dict, List, Literal, Optional, Set, Tuple, Union
 
 import joblib
 import numpy as np
-import requests
 import torch
 from huggingface_hub import ModelHubMixin, hf_hub_download
-from huggingface_hub.utils import validate_hf_hub_args
+from huggingface_hub.utils import EntryNotFoundError, HfHubHTTPError, validate_hf_hub_args
 from packaging.version import Version, parse
 from sentence_transformers import SentenceTransformer
 from sentence_transformers import __version__ as sentence_transformers_version
-from sentence_transformers import models
 from sklearn.linear_model import LogisticRegression
 from sklearn.multiclass import OneVsRestClassifier
 from sklearn.multioutput import ClassifierChain, MultiOutputClassifier
@@ -24,6 +22,7 @@ from tqdm.auto import tqdm, trange
 from transformers.utils import copy_func
 
 from . import logging
+from .compat import Dense
 from .data import SetFitDataset
 from .model_card import SetFitModelCardData, generate_model_card
 from .utils import set_docstring
@@ -36,7 +35,7 @@ MODEL_HEAD_NAME = "model_head.pkl"
 CONFIG_NAME = "config_setfit.json"
 
 
-class SetFitHead(models.Dense):
+class SetFitHead(Dense):
     """
     A SetFit head that supports multi-class classification for end-to-end training.
     Binary classification is treated as 2-class classification.
@@ -73,7 +72,7 @@ class SetFitHead(models.Dense):
         device: Optional[Union[torch.device, str]] = None,
         multitarget: bool = False,
     ) -> None:
-        super(models.Dense, self).__init__()  # init on models.Dense's parent: nn.Module
+        super(Dense, self).__init__()  # skip Dense.__init__, the linear layer is set up below
 
         if out_features == 1:
             logger.warning(
@@ -756,6 +755,21 @@ class SetFitModel(ModelHubMixin):
             device = model_body._target_device
         model_body.to(device)  # put `model_body` on the target device
 
+        # huggingface_hub v1.0 removed the proxies and resume_download arguments, and its offline cache miss
+        # is an EntryNotFoundError that no longer inherits from HfHubHTTPError
+        download_kwargs = {
+            "repo_id": model_id,
+            "revision": revision,
+            "cache_dir": cache_dir,
+            "force_download": force_download,
+            "token": token,
+            "local_files_only": local_files_only,
+        }
+        if proxies is not None:
+            download_kwargs["proxies"] = proxies
+        if resume_download is not None:
+            download_kwargs["resume_download"] = resume_download
+
         # Try to load a SetFit config file
         config_file: Optional[str] = None
         if os.path.isdir(model_id):
@@ -763,18 +777,8 @@ class SetFitModel(ModelHubMixin):
                 config_file = os.path.join(model_id, CONFIG_NAME)
         else:
             try:
-                config_file = hf_hub_download(
-                    repo_id=model_id,
-                    filename=CONFIG_NAME,
-                    revision=revision,
-                    cache_dir=cache_dir,
-                    force_download=force_download,
-                    proxies=proxies,
-                    resume_download=resume_download,
-                    token=token,
-                    local_files_only=local_files_only,
-                )
-            except requests.exceptions.RequestException:
+                config_file = hf_hub_download(filename=CONFIG_NAME, **download_kwargs)
+            except (HfHubHTTPError, EntryNotFoundError):
                 pass
 
         model_kwargs = {key: value for key, value in model_kwargs.items() if value is not None}
@@ -805,18 +809,8 @@ class SetFitModel(ModelHubMixin):
                 model_head_file = None
         else:
             try:
-                model_head_file = hf_hub_download(
-                    repo_id=model_id,
-                    filename=MODEL_HEAD_NAME,
-                    revision=revision,
-                    cache_dir=cache_dir,
-                    force_download=force_download,
-                    proxies=proxies,
-                    resume_download=resume_download,
-                    token=token,
-                    local_files_only=local_files_only,
-                )
-            except requests.exceptions.RequestException:
+                model_head_file = hf_hub_download(filename=MODEL_HEAD_NAME, **download_kwargs)
+            except (HfHubHTTPError, EntryNotFoundError):
                 logger.info(
                     f"{MODEL_HEAD_NAME} not found on HuggingFace Hub, initialising classification head with random weights."
                     " You should TRAIN this model on a downstream task to use it for predictions and inference."
@@ -881,7 +875,7 @@ class SetFitModel(ModelHubMixin):
         )
 
 
-docstring = SetFitModel.from_pretrained.__doc__
+docstring = SetFitModel.from_pretrained.__doc__ or ""
 cut_index = docstring.find("model_kwargs")
 if cut_index != -1:
     docstring = (
@@ -918,6 +912,7 @@ if cut_index != -1:
     SetFitModel.from_pretrained = set_docstring(SetFitModel.from_pretrained, docstring)
 
 SetFitModel.save_pretrained = copy_func(SetFitModel.save_pretrained)
-SetFitModel.save_pretrained.__doc__ = SetFitModel.save_pretrained.__doc__.replace(
-    "~ModelHubMixin._from_pretrained", "SetFitModel.push_to_hub"
-)
+if SetFitModel.save_pretrained.__doc__:
+    SetFitModel.save_pretrained.__doc__ = SetFitModel.save_pretrained.__doc__.replace(
+        "~ModelHubMixin._from_pretrained", "SetFitModel.push_to_hub"
+    )

--- a/src/setfit/span/modeling.py
+++ b/src/setfit/span/modeling.py
@@ -103,7 +103,7 @@ class SpanSetFitModel(SetFitModel):
             f.write(self.generate_model_card())
 
 
-docstring = SpanSetFitModel.from_pretrained.__doc__
+docstring = SpanSetFitModel.from_pretrained.__doc__ or ""
 cut_index = docstring.find("multi_target_strategy")
 if cut_index != -1:
     docstring = (

--- a/src/setfit/trainer.py
+++ b/src/setfit/trainer.py
@@ -4,14 +4,9 @@ from typing import TYPE_CHECKING, Any, Callable, Dict, Iterable, List, Literal, 
 import evaluate
 import torch
 from datasets import Dataset, DatasetDict
-from packaging.version import parse as parse_version
-from sentence_transformers import SentenceTransformerTrainer, losses
-from sentence_transformers.losses.BatchHardTripletLoss import BatchHardTripletLossDistanceFunction
-from sentence_transformers.model_card import ModelCardCallback as STModelCardCallback
-from sentence_transformers.training_args import BatchSamplers, SentenceTransformerTrainingArguments
+from sentence_transformers import SentenceTransformerTrainer, SentenceTransformerTrainingArguments
 from sklearn.preprocessing import LabelEncoder
 from torch import nn
-from transformers import __version__ as transformers_version
 from transformers.integrations import CodeCarbonCallback
 from transformers.trainer_callback import IntervalStrategy, TrainerCallback
 from transformers.trainer_utils import HPSearchBackend, default_compute_objective, number_of_arguments, set_seed
@@ -20,6 +15,7 @@ from transformers.utils.import_utils import is_in_notebook
 from setfit.model_card import ModelCardCallback
 
 from . import logging
+from .compat import TRANSFORMERS_VERSION, BatchSamplers, SentenceTransformerModelCardCallback, Version, losses
 from .integrations import default_hp_search_backend, is_optuna_available, run_hp_search_optuna
 from .losses import SupConLoss
 from .sampler import ContrastiveDataset
@@ -47,9 +43,15 @@ class BCSentenceTransformersTrainer(SentenceTransformerTrainer):
         self._setfit_model = setfit_model
         self._setfit_args = setfit_args
         self.logs_prefix = "embedding"
+        # The Trainer creates the integration callbacks (TensorBoard, CodeCarbon, ...) during initialization,
+        # so report_to has to be known already
         super().__init__(
             model=setfit_model.model_body,
-            args=SentenceTransformerTrainingArguments(output_dir=setfit_args.output_dir),
+            args=SentenceTransformerTrainingArguments(
+                output_dir=setfit_args.output_dir,
+                report_to=setfit_args.report_to,
+                seed=setfit_args.seed,
+            ),
             **kwargs,
         )
         self._apply_training_arguments(setfit_args)
@@ -58,7 +60,7 @@ class BCSentenceTransformersTrainer(SentenceTransformerTrainer):
             if isinstance(callback, CodeCarbonCallback):
                 self.setfit_model.model_card_data.code_carbon_callback = callback
 
-            if isinstance(callback, STModelCardCallback):
+            if isinstance(callback, SentenceTransformerModelCardCallback):
                 self.remove_callback(callback)
 
         if is_in_notebook():
@@ -70,6 +72,7 @@ class BCSentenceTransformersTrainer(SentenceTransformerTrainer):
                 self.add_callback(SetFitNotebookProgressCallback)
 
         def overwritten_call_event(self, event, args, state, control, **kwargs):
+            processing_class = self.processing_class if TRANSFORMERS_VERSION >= Version("4.46.0") else self.tokenizer
             for callback in self.callbacks:
                 result = getattr(callback, event)(
                     self.setfit_args,
@@ -78,11 +81,8 @@ class BCSentenceTransformersTrainer(SentenceTransformerTrainer):
                     model=self.setfit_model,
                     st_model=self.model,
                     st_args=args,
-                    tokenizer=(
-                        self.processing_class
-                        if parse_version(transformers_version) >= parse_version("4.46.0")
-                        else self.tokenizer
-                    ),
+                    tokenizer=processing_class,
+                    processing_class=processing_class,
                     optimizer=self.optimizer,
                     lr_scheduler=self.lr_scheduler,
                     train_dataloader=self.train_dataloader,
@@ -130,6 +130,7 @@ class BCSentenceTransformersTrainer(SentenceTransformerTrainer):
         """
         Propagate the SetFit TrainingArguments to the SentenceTransformer Trainer.
         """
+        args._transformers_args = self.args
         self.args.output_dir = args.output_dir
 
         self.args.per_device_train_batch_size = args.embedding_batch_size
@@ -142,9 +143,13 @@ class BCSentenceTransformersTrainer(SentenceTransformerTrainer):
         self.args.seed = args.seed
         self.args.report_to = args.report_to
         self.args.run_name = args.run_name
-        self.args.warmup_ratio = args.warmup_proportion
+        if TRANSFORMERS_VERSION >= Version("5.0.0"):
+            # transformers v5 replaced warmup_ratio with a fractional warmup_steps and dropped logging_dir
+            self.args.warmup_steps = args.warmup_proportion
+        else:
+            self.args.warmup_ratio = args.warmup_proportion
+            self.args.logging_dir = args.logging_dir
 
-        self.args.logging_dir = args.logging_dir
         self.args.logging_strategy = args.logging_strategy
         self.args.logging_first_step = args.logging_first_step
         self.args.logging_steps = args.logging_steps
@@ -532,7 +537,7 @@ class Trainer(ColumnMappingMixin):
         self.train_classifier(*train_parameters, args=args)
 
     def dataset_to_parameters(self, dataset: Dataset) -> List[Iterable]:
-        return [dataset["text"], dataset["label"]]
+        return [list(dataset["text"]), list(dataset["label"])]
 
     def train_embeddings(
         self,
@@ -682,8 +687,8 @@ class Trainer(ColumnMappingMixin):
         if eval_dataset is None:
             raise ValueError("No evaluation dataset provided to `Trainer.evaluate` nor the `Trainer` initialzation.")
 
-        x_test = eval_dataset["text"]
-        y_test = eval_dataset["label"]
+        x_test = list(eval_dataset["text"])
+        y_test = list(eval_dataset["label"])
 
         logger.info("***** Running evaluation *****")
         y_pred = self.model.predict(x_test, use_labels=False)
@@ -860,7 +865,7 @@ class SetFitTrainer(Trainer):
         column_mapping: Optional[Dict[str, str]] = None,
         use_amp: bool = False,
         warmup_proportion: float = 0.1,
-        distance_metric: Callable = BatchHardTripletLossDistanceFunction.cosine_distance,
+        distance_metric: Callable = losses.BatchHardTripletLossDistanceFunction.cosine_distance,
         margin: float = 0.25,
         samples_per_label: int = 2,
     ):

--- a/src/setfit/trainer_distillation.py
+++ b/src/setfit/trainer_distillation.py
@@ -3,11 +3,12 @@ from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Optional, Tupl
 
 import torch
 from datasets import Dataset
-from sentence_transformers import losses, util
+from sentence_transformers import util
 from torch import nn
 from torch.utils.data import DataLoader
 
 from . import logging
+from .compat import losses
 from .sampler import ContrastiveDistillationDataset
 from .trainer import Trainer
 from .training_args import TrainingArguments
@@ -75,7 +76,7 @@ class DistillationTrainer(Trainer):
         self.student_model = self.model
 
     def dataset_to_parameters(self, dataset: Dataset) -> List[Iterable]:
-        return [dataset["text"]]
+        return [list(dataset["text"])]
 
     def get_dataset(
         self,

--- a/src/setfit/training_args.py
+++ b/src/setfit/training_args.py
@@ -7,13 +7,12 @@ from dataclasses import dataclass, field, fields
 from typing import Any, Callable, Dict, Optional, Tuple, Union
 
 import torch
-from sentence_transformers import losses
 from transformers import IntervalStrategy
 from transformers.integrations import get_available_reporting_integrations
-from transformers.training_args import default_logdir
 from transformers.utils import is_torch_available
 
 from . import logging
+from .compat import TRANSFORMERS_VERSION, Version, default_logdir, losses
 
 
 logger = logging.get_logger(__name__)
@@ -112,7 +111,8 @@ class TrainingArguments:
             [mlflow](https://www.mlflow.org/) logging.
         logging_dir (`str`, *optional*):
             [TensorBoard](https://www.tensorflow.org/tensorboard) log directory. Will default to
-            *runs/**CURRENT_DATETIME_HOSTNAME***.
+            *runs/**CURRENT_DATETIME_HOSTNAME***. Only used with `transformers` < 5.0.0, newer versions ignore
+            this argument and use the `TENSORBOARD_LOGGING_DIR` environment variable instead.
         logging_strategy (`str` or [`~transformers.trainer_utils.IntervalStrategy`], *optional*, defaults to `"steps"`):
             The logging strategy to adopt during training. Possible values are:
 
@@ -247,7 +247,13 @@ class TrainingArguments:
             self.report_to = [self.report_to]
 
         if self.logging_dir is None:
-            self.logging_dir = default_logdir()
+            if TRANSFORMERS_VERSION < Version("5.0.0"):
+                self.logging_dir = default_logdir()
+        elif TRANSFORMERS_VERSION >= Version("5.0.0"):
+            logger.warning(
+                "`logging_dir` is ignored with transformers >= 5.0.0. "
+                "Set the `TENSORBOARD_LOGGING_DIR` environment variable instead."
+            )
 
         self.logging_strategy = IntervalStrategy(self.logging_strategy)
         if self.evaluation_strategy is not None:
@@ -291,6 +297,14 @@ class TrainingArguments:
 
         if self.samples_per_label != 2:
             logger.warning("The `samples_per_label` argument is deprecated and will be removed in a future version.")
+
+    def __getattr__(self, name: str) -> Any:
+        # Only reached when the regular lookup fails. Callbacks from transformers may read arguments that
+        # only exist on transformers' TrainingArguments, so defer to those of the underlying Trainer if known
+        transformers_args = self.__dict__.get("_transformers_args")
+        if name.startswith("_") or transformers_args is None:
+            raise AttributeError(f"'{type(self).__name__}' object has no attribute '{name}'")
+        return getattr(transformers_args, name)
 
     @property
     def embedding_batch_size(self) -> int:

--- a/src/setfit/utils.py
+++ b/src/setfit/utils.py
@@ -5,9 +5,9 @@ from time import monotonic_ns
 from typing import Any, Dict, List, NamedTuple, Optional, Tuple
 
 from datasets import Dataset, DatasetDict, load_dataset
-from sentence_transformers import losses
 from transformers.utils import copy_func
 
+from .compat import losses
 from .data import create_fewshot_splits, create_fewshot_splits_multilabel
 from .losses import SupConLoss
 

--- a/tests/exporters/test_openvino.py
+++ b/tests/exporters/test_openvino.py
@@ -1,12 +1,14 @@
 import os
 
 import numpy as np
-import openvino.runtime as ov
 import pytest
 from transformers import AutoTokenizer
 
 from setfit import SetFitModel
-from setfit.exporters.openvino import export_to_openvino
+
+
+ov = pytest.importorskip("openvino")
+export_to_openvino = pytest.importorskip("setfit.exporters.openvino").export_to_openvino
 
 
 @pytest.mark.skip(

--- a/tests/test_deprecated_trainer.py
+++ b/tests/test_deprecated_trainer.py
@@ -6,11 +6,11 @@ import evaluate
 import pytest
 import torch
 from datasets import Dataset, load_dataset
-from sentence_transformers import losses
 from transformers.testing_utils import require_optuna
 from transformers.utils.hp_naming import TrialShortNamer
 
 from setfit import logging
+from setfit.compat import losses
 from setfit.losses import SupConLoss
 from setfit.modeling import SetFitModel
 from setfit.trainer import SetFitTrainer
@@ -404,20 +404,20 @@ class TrainerHyperParameterOptunaIntegrationTest(TestCase):
 
     def test_hyperparameter_search(self):
         class MyTrialShortNamer(TrialShortNamer):
-            DEFAULTS = {"max_iter": 100, "solver": "liblinear"}
+            DEFAULTS = {"max_iter": 100, "solver": "lbfgs"}
 
         def hp_space(trial):
             return {
                 "learning_rate": trial.suggest_float("learning_rate", 1e-6, 1e-4, log=True),
                 "batch_size": trial.suggest_categorical("batch_size", [4, 8, 16, 32, 64]),
                 "max_iter": trial.suggest_int("max_iter", 50, 300),
-                "solver": trial.suggest_categorical("solver", ["newton-cg", "lbfgs", "liblinear"]),
+                "solver": trial.suggest_categorical("solver", ["newton-cg", "lbfgs"]),
             }
 
         def model_init(params):
             params = params or {}
             max_iter = params.get("max_iter", 100)
-            solver = params.get("solver", "liblinear")
+            solver = params.get("solver", "lbfgs")
             params = {
                 "head_params": {
                     "max_iter": max_iter,

--- a/tests/test_deprecated_trainer_distillation.py
+++ b/tests/test_deprecated_trainer_distillation.py
@@ -2,9 +2,9 @@ from unittest import TestCase
 
 import pytest
 from datasets import Dataset
-from sentence_transformers.losses import CosineSimilarityLoss
 
 from setfit import DistillationSetFitTrainer, SetFitTrainer
+from setfit.compat import losses
 from setfit.modeling import SetFitModel
 
 
@@ -21,7 +21,7 @@ class DistillationSetFitTrainerTest(TestCase):
             model=self.teacher_model,
             train_dataset=dataset,
             eval_dataset=dataset,
-            loss_class=CosineSimilarityLoss,
+            loss_class=losses.CosineSimilarityLoss,
             metric="accuracy",
         )
         # Teacher Train and evaluate
@@ -33,7 +33,7 @@ class DistillationSetFitTrainerTest(TestCase):
             train_dataset=dataset,
             student_model=self.student_model,
             eval_dataset=dataset,
-            loss_class=CosineSimilarityLoss,
+            loss_class=losses.CosineSimilarityLoss,
             metric="accuracy",
         )
 

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -13,7 +13,7 @@ from .model_card_pattern import MODEL_CARD_PATTERN
 
 
 def test_model_card(tmp_path: Path) -> None:
-    dataset = load_dataset("sst2")
+    dataset = load_dataset("stanfordnlp/sst2")
     train_dataset = sample_dataset(dataset["train"], label_column="label", num_samples=8)
     eval_dataset = dataset["validation"].select(range(10))
     model = SetFitModel.from_pretrained(

--- a/tests/test_model_card.py
+++ b/tests/test_model_card.py
@@ -87,3 +87,9 @@ def test_cant_infer_dataset_id():
     # This triggers inferring the dataset_id from train_dataset
     Trainer(model=model, train_dataset=train_dataset)
     assert model.model_card_data.dataset_id is None
+
+
+def test_model_card_before_training(model: SetFitModel) -> None:
+    pytest.importorskip("codecarbon")
+    Trainer(model, args=TrainingArguments(report_to="codecarbon"))
+    assert "SetFit" in model.generate_model_card()

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -148,7 +148,7 @@ class SetFitModelDifferentiableHeadTest(TestCase):
 
         # check the model body's gradients
         for name, param in self.model.model_body.named_parameters():
-            if "0.auto_model.pooler" in name:  # ignore pooler
+            if ".pooler." in name:  # ignore pooler, mean pooling does not use it
                 continue
 
             assert param.grad is not None, f"Gradients of {name} in the model body is None."
@@ -187,6 +187,13 @@ def test_setfit_from_pretrained_local_model_with_head(tmp_path):
     model = SetFitModel.from_pretrained(str(tmp_path.absolute()))
 
     assert isinstance(model, SetFitModel)
+
+
+def test_from_pretrained_local_files_only_without_setfit_files() -> None:
+    model_id = "sentence-transformers/paraphrase-albert-small-v2"
+    SetFitModel.from_pretrained(model_id)  # warm the cache
+    model = SetFitModel.from_pretrained(model_id, local_files_only=True)
+    assert isinstance(model.model_head, LogisticRegression)
 
 
 def test_setfithead_multitarget_from_pretrained():

--- a/tests/test_modeling.py
+++ b/tests/test_modeling.py
@@ -76,7 +76,7 @@ def test_setfit_multilabel_classifier_chain_classifier_model_head():
 class SetFitModelDifferentiableHeadTest(TestCase):
     @classmethod
     def setUpClass(cls):
-        dataset = load_dataset("sst2")
+        dataset = load_dataset("stanfordnlp/sst2")
         num_classes = 2
         train_dataset = dataset["train"].shuffle(seed=42).select(range(2 * num_classes))
         x_train, y_train = train_dataset["sentence"], train_dataset["label"]

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -608,8 +608,9 @@ def test_trainer_wrong_args(model: SetFitModel) -> None:
 
 def test_trainer_report_to(model: SetFitModel) -> None:
     trainer = Trainer(model, args=TrainingArguments(report_to="none"))
-    callback_names = {callback.__class__.__name__ for callback in trainer.st_trainer.callback_handler.callbacks}
-    assert callback_names == {"DefaultFlowCallback", "ProgressCallback", "ModelCardCallback"}
+    callbacks = trainer.st_trainer.callback_handler.callbacks
+    assert not any(type(callback).__module__.startswith("transformers.integrations") for callback in callbacks)
+    assert {"DefaultFlowCallback", "ModelCardCallback"} <= {type(callback).__name__ for callback in callbacks}
 
     pytest.importorskip("codecarbon")
     trainer = Trainer(model, args=TrainingArguments(report_to="codecarbon"))

--- a/tests/test_trainer.py
+++ b/tests/test_trainer.py
@@ -7,12 +7,13 @@ import evaluate
 import pytest
 import torch
 from datasets import Dataset, load_dataset
-from sentence_transformers import losses
 from transformers import TrainerCallback
+from transformers.integrations import CodeCarbonCallback
 from transformers.testing_utils import require_optuna
 from transformers.utils.hp_naming import TrialShortNamer
 
 from setfit import logging
+from setfit.compat import losses
 from setfit.losses import SupConLoss
 from setfit.modeling import SetFitModel
 from setfit.trainer import Trainer
@@ -398,20 +399,20 @@ class TrainerHyperParameterOptunaIntegrationTest(TestCase):
 
     def test_hyperparameter_search(self):
         class MyTrialShortNamer(TrialShortNamer):
-            DEFAULTS = {"max_iter": 100, "solver": "liblinear"}
+            DEFAULTS = {"max_iter": 100, "solver": "lbfgs"}
 
         def hp_space(trial):
             return {
                 "learning_rate": trial.suggest_float("learning_rate", 1e-6, 1e-4, log=True),
                 "batch_size": trial.suggest_categorical("batch_size", [4, 8, 16, 32, 64]),
                 "max_iter": trial.suggest_int("max_iter", 50, 300),
-                "solver": trial.suggest_categorical("solver", ["newton-cg", "lbfgs", "liblinear"]),
+                "solver": trial.suggest_categorical("solver", ["newton-cg", "lbfgs"]),
             }
 
         def model_init(params):
             params = params or {}
             max_iter = params.get("max_iter", 100)
-            solver = params.get("solver", "liblinear")
+            solver = params.get("solver", "lbfgs")
             params = {
                 "head_params": {
                     "max_iter": max_iter,
@@ -603,3 +604,20 @@ def test_trainer_wrong_args(model: SetFitModel) -> None:
     expected = "`args` must be a `TrainingArguments` instance imported from `setfit`."
     with pytest.raises(ValueError, match=expected):
         Trainer(model, dataset)
+
+
+def test_trainer_report_to(model: SetFitModel) -> None:
+    trainer = Trainer(model, args=TrainingArguments(report_to="none"))
+    callback_names = {callback.__class__.__name__ for callback in trainer.st_trainer.callback_handler.callbacks}
+    assert callback_names == {"DefaultFlowCallback", "ProgressCallback", "ModelCardCallback"}
+
+    pytest.importorskip("codecarbon")
+    trainer = Trainer(model, args=TrainingArguments(report_to="codecarbon"))
+    callbacks = trainer.st_trainer.callback_handler.callbacks
+    assert any(isinstance(callback, CodeCarbonCallback) for callback in callbacks)
+    assert model.model_card_data.code_carbon_callback in callbacks
+
+
+def test_trainer_warmup_proportion(model: SetFitModel) -> None:
+    trainer = Trainer(model, args=TrainingArguments(warmup_proportion=0.25))
+    assert trainer.st_trainer.args.get_warmup_steps(100) == 25


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Introduce compatibility with transformers v5, Sentence Transformers v5.4 and v6, huggingface_hub v1 and datasets v4 and v5
* Add Python 3.13 support and rework the CI matrix into explicit dependency presets
* Fix ONNX export with recent torch, onnx and skl2onnx releases

## Details
SetFit had fallen behind the rest of the ecosystem. It no longer imported on transformers v5 (`default_logdir` moved), loading any model from the Hub failed on huggingface_hub v1 (`HfHubHTTPError` no longer derives from `requests`, and `proxies` and `resume_download` were removed from `hf_hub_download`), every `sentence_transformers.losses`, `models`, `training_args` and `model_card` import warns on Sentence Transformers v5.4+, and the CI had been red on every cell since April. This PR keeps support for the old versions (transformers 4.41, Sentence Transformers 3.0, huggingface_hub 0.24, datasets 2.15) while adding the new ones.

The version dependent imports now live in `setfit/compat.py`, which tries the Sentence Transformers v5.4+ module paths first and falls back to the old ones, and imports `default_logdir` from `transformers.integrations.integration_utils` with a fallback. `SetFitModel.from_pretrained` catches both `HfHubHTTPError` and `EntryNotFoundError`, because on huggingface_hub v1 the offline and `local_files_only=True` misses raise a `LocalEntryNotFoundError` that no longer inherits from `HfHubHTTPError`.

On transformers v5, `warmup_ratio` and `logging_dir` are gone, so the warmup proportion is now passed as a fractional `warmup_steps`, and `logging_dir` is ignored with a warning (v5 reads `TENSORBOARD_LOGGING_DIR` instead). `report_to` and `seed` are now given to the inner `SentenceTransformerTrainingArguments` at construction, since the integration callbacks are created in `Trainer.__init__`. Before, `report_to` was applied afterwards and silently ignored: `report_to="none"` still attached the CodeCarbon callback on transformers v4, and with the v5 default of `"none"` all reporting would have disappeared. So `report_to` is honoured now, which is a small behaviour change. Finally, the integration callbacks of transformers (Trackio, W&B) started reading arguments that the SetFit `TrainingArguments` does not define, such as `args.project`, so the SetFit arguments now defer unknown attributes to the transformers arguments of the underlying trainer. Custom callbacks keep receiving the SetFit arguments as before.

datasets v4 returns a lazy `Column` for `dataset["text"]`, which is converted to a list in `Trainer.evaluate` and `dataset_to_parameters`. The ONNX exporter requests the legacy exporter explicitly (torch 2.9 defaults to the dynamo based one, which does not support the opsets used here) and converts the scikit-learn head with a float32 input, matching the float32 embeddings of the body. The double precision path it used to have never actually ran: its type check compared against an `onnxconverter_common` class that skl2onnx stopped using, and skl2onnx 1.20 no longer ships that dependency at all. `openvino.runtime` was removed in openvino 2026, so the OpenVINO exporter falls back to the top level API. The model card skips emissions data when the codecarbon tracker cannot report, since recent codecarbon 3.x releases raise for a tracker that was never started, e.g. when saving before training with codecarbon installed.

On the packaging side, `evaluate>=0.4.6` is required as older versions cannot download metric scripts with huggingface_hub v1 (`HfFolder` is gone), the codecarbon range excludes 2.6 (print spam) and 2.7 and 2.8 (a second tracker in the same process, which `AbsaTrainer` creates, fails with a missing `_cloud`), `hummingbird-ml` moved out of the `tests` extra as it pins `onnx<=1.16.1` without Python 3.13 wheels, and spaCy is unpinned on Python 3.10+. Python 3.9 keeps `spacy<3.8`, `numpy<2` and `onnx<1.17` through environment markers: the spaCy 3.8 line depends on blis releases without 3.9 wheels, the spaCy 3.7 binaries need numpy 1.x, and the 3.9 wheels of onnx 1.17 to 1.19 crash on Windows once `pyarrow.dataset` has been imported. These were previously hidden by the `spacy<3.7.6` pin and by the openvino and hummingbird extras pinning numpy and onnx.

The CI matrix now runs `.[tests]` on Python 3.9 to 3.13 on both operating systems, plus two presets as `include` entries: `.[compat_tests]` (the minimum pins) on 3.9 and the new `.[compat_tests_v4]` (transformers<5, sentence-transformers<6, huggingface_hub<1, datasets<5) on 3.11. That is 14 jobs instead of 16. The minimum pins no longer run on 3.12, where pandas 1.5.3 has no wheels (that cell failed at the install step before), and the three presets cover each branch in `setfit/compat.py`: Sentence Transformers 3.0, 4 to 5.3, and 5.4+, next to transformers v4 versus v5 and huggingface_hub v0 versus v1. Without the v4 preset, that generation was only tested because Python 3.9 happens to resolve to it.

I ran the full suite locally on Windows for each kind of cell:

| Cell | Resolution | Result |
|---|---|---|
| `.[tests]`, Python 3.13 | transformers 5.16.1, sentence-transformers 6.0.1, huggingface_hub 1.30.0, datasets 5.0.1, torch 2.14.0 | 158 passed, 17 skipped |
| `.[tests]`, Python 3.9 | transformers 4.57.6, sentence-transformers 5.1.2, huggingface_hub 0.36.2, datasets 4.5.0, onnx 1.16.1 | 158 passed, 17 skipped |
| `.[compat_tests_v4]`, Python 3.11 | transformers 4.57.6, sentence-transformers 5.7.0, huggingface_hub 0.36.2, datasets 4.8.5 | 158 passed, 17 skipped |
| `.[compat_tests]`, Python 3.9 | transformers 4.41.0, sentence-transformers 3.0.0, huggingface_hub 0.24.0, datasets 2.15.0 | 158 passed, 17 skipped |

The skips are the CUDA only tests, the OpenVINO test and the two Optuna tests (optuna is not part of `.[tests]`). The suite also passes against the sentence-transformers 6.1 dev checkout with transformers 5.15 and huggingface_hub 1.24, with the Sentence Transformers deprecated import warnings turned into errors.

A few caveats. With transformers v5, `warmup_proportion=1.0` results in a single warmup step, as transformers reads a `warmup_steps` of 1 or more as a step count. The hyperparameter search tests no longer sample the `liblinear` solver, which scikit-learn 1.9 rejects for multiclass problems, and the hyperparameter optimization guide has the same solver in its search space.

- Tom Aarsen
