### PR TITLE
Use namespaced dataset ids in README, docs and notebooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ from setfit import SetFitModel, Trainer, TrainingArguments, sample_dataset
 
 
 # Load a dataset from the Hugging Face Hub
-dataset = load_dataset("sst2")
+dataset = load_dataset("stanfordnlp/sst2")
 
 # Simulate the few-shot regime by sampling 8 examples per class
 train_dataset = sample_dataset(dataset["train"], label_column="label", num_samples=8)

--- a/docs/source/en/how_to/knowledge_distillation.mdx
+++ b/docs/source/en/how_to/knowledge_distillation.mdx
@@ -9,14 +9,14 @@ This guide will show you how to proceed with knowledge distillation.
 
 ## Data preparation
 
-Let's consider a scenario with a little bit of labeled training data (e.g. 64 sentences). We will simulate this scenario using the [ag_news](https://huggingface.co/datasets/ag_news) dataset for this guide.
+Let's consider a scenario with a little bit of labeled training data (e.g. 64 sentences). We will simulate this scenario using the [ag_news](https://huggingface.co/datasets/fancyzhx/ag_news) dataset for this guide.
 
 ```py
 from datasets import load_dataset
 from setfit import sample_dataset
 
 # Load a dataset from the Hugging Face Hub
-dataset = load_dataset("ag_news")
+dataset = load_dataset("fancyzhx/ag_news")
 
 # Create a sample few-shot dataset to train with
 train_dataset = sample_dataset(dataset["train"], label_column="label", num_samples=16)
@@ -205,7 +205,7 @@ from datasets import load_dataset
 from setfit import sample_dataset
 
 # Load a dataset from the Hugging Face Hub
-dataset = load_dataset("ag_news")
+dataset = load_dataset("fancyzhx/ag_news")
 
 # Create a sample few-shot dataset to train with
 train_dataset = sample_dataset(dataset["train"], label_column="label", num_samples=16)

--- a/docs/source/en/tutorials/zero_shot.mdx
+++ b/docs/source/en/tutorials/zero_shot.mdx
@@ -22,7 +22,7 @@ If you're running this Notebook on Colab or some other cloud platform, you will 
 To benchmark the performance of the "zero-shot" method, we'll use the following dataset and pretrained model: 
 
 ```py
-dataset_id = "emotion"
+dataset_id = "dair-ai/emotion"
 model_id = "sentence-transformers/paraphrase-mpnet-base-v2"
 ```
 

--- a/notebooks/setfit-optimum-intel.ipynb
+++ b/notebooks/setfit-optimum-intel.ipynb
@@ -963,7 +963,7 @@
     }
    ],
    "source": [
-    "calibration_set = load_dataset(\"rotten_tomatoes\")[\"train\"].shuffle(seed=42).select(range(100))  \n",
+    "calibration_set = load_dataset(\"cornell-movie-review-data/rotten_tomatoes\")[\"train\"].shuffle(seed=42).select(range(100))  \n",
     "calibration_set[\"text\"][:2]"
    ]
   },

--- a/notebooks/text-classification.ipynb
+++ b/notebooks/text-classification.ipynb
@@ -118,7 +118,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset_id = \"sst2\"\n",
+    "dataset_id = \"stanfordnlp/sst2\"\n",
     "model_id = \"sentence-transformers/paraphrase-mpnet-base-v2\""
    ]
   },

--- a/notebooks/zero-shot-classification.ipynb
+++ b/notebooks/zero-shot-classification.ipynb
@@ -66,7 +66,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "dataset_id = \"emotion\"\n",
+    "dataset_id = \"dair-ai/emotion\"\n",
     "model_id = \"sentence-transformers/paraphrase-mpnet-base-v2\""
    ]
   },


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Replace namespace-less dataset ids such as `sst2` with their canonical namespaced repositories in the README, docs and notebooks

## Details
Loading a canonical dataset by its old namespace-less id (e.g. `load_dataset("sst2")`) no longer works with recent `datasets` and `huggingface_hub` releases, so the README quickstart, the knowledge distillation guide, the zero-shot tutorial and several notebooks currently fail at the very first step. I've replaced these ids with the repositories the Hub redirects them to: `stanfordnlp/sst2`, `fancyzhx/ag_news`, `dair-ai/emotion` and `cornell-movie-review-data/rotten_tomatoes`. All four are parquet-backed, so they also load with `datasets` v4+, which dropped support for dataset loading scripts.

The `sst2` defaults in the `scripts/` directory are intentionally left untouched. Those scripts prepend `SetFit/` and load the `SetFit/sst2` copy, which still resolves.

Two notebooks still load `ethos` and `financial_phrasebank`. Their canonical repositories (`iamollas/ethos` and `takala/financial_phrasebank`) only ship a loading script, so renaming the id alone would not make them load with `datasets` v4+. Those need a different data source and are out of scope here.

- Tom Aarsen
