### PR TITLE
Pin the doc-builder workflows to their pre-#648 revisions

### DIFF
--- a/.github/workflows/build_documentation.yml
+++ b/.github/workflows/build_documentation.yml
@@ -9,7 +9,8 @@ on:
 
 jobs:
    build:
-    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@c2d27f6f231df3d1b07f3a7ea54fe3d0f8bc3e27  # main
+    # Pinned before the doc-builder light install (huggingface/doc-builder#801), which skips the real dependencies of setfit
+    uses: huggingface/doc-builder/.github/workflows/build_main_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
     with:
       commit_sha: ${{ github.sha }}
       package: setfit

--- a/.github/workflows/build_pr_documentation.yml
+++ b/.github/workflows/build_pr_documentation.yml
@@ -9,7 +9,8 @@ concurrency:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@c2d27f6f231df3d1b07f3a7ea54fe3d0f8bc3e27  # main
+    # Pinned before the doc-builder light install (huggingface/doc-builder#801), which skips the real dependencies of setfit
+    uses: huggingface/doc-builder/.github/workflows/build_pr_documentation.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
     with:
       commit_sha: ${{ github.event.pull_request.head.sha }}
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/delete_doc_comment_trigger.yml
+++ b/.github/workflows/delete_doc_comment_trigger.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   delete:
-    uses: huggingface/doc-builder/.github/workflows/delete_doc_comment_trigger.yml@c2d27f6f231df3d1b07f3a7ea54fe3d0f8bc3e27  # main
+    uses: huggingface/doc-builder/.github/workflows/delete_doc_comment_trigger.yml@90b4ee2c10b81b5c1a6367c4e6fc9e2fb510a7e3  # main
     with:
       pr_number: ${{ github.event.number }}

--- a/.github/workflows/upload_pr_documentation.yml
+++ b/.github/workflows/upload_pr_documentation.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   build:
-    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@c2d27f6f231df3d1b07f3a7ea54fe3d0f8bc3e27  # main
+    uses: huggingface/doc-builder/.github/workflows/upload_pr_documentation.yml@9ad2de8582b56c017cb530c1165116d40433f1c6  # main
     with:
       package_name: setfit
     secrets:


### PR DESCRIPTION
Hello!

Heads up, this PR was AI-generated and human-reviewed.

## Pull Request overview
* Pin the doc-builder reusable workflows back to the revisions used before #648

## Details
Every docs build since #648 fails, including the ones for #649 and the v1.2.0 release commit, while every build before it passed. The bump moved the reusable workflows past https://github.com/huggingface/doc-builder/pull/801, which introduced a light install: when doc-builder has a mock-deps registry entry for the package, the workflow installs the package with `--no-deps` and then only the packages that the entry lists as `real:`. The entry for setfit only lists packages to mock and no real ones, so `datasets`, `pandas`, `transformers`, `huggingface_hub` and `evaluate` are never installed and importing setfit fails with `ModuleNotFoundError: No module named 'pandas'`.

This PR pins the four workflows back to the revisions in use before #648, which do a full `[dev]` install. Those revisions built, uploaded and commented on the #649 docs earlier today, so they are known to work end to end.

Two follow-ups. Dependabot will propose the same bump again, so its PRs for `huggingface/doc-builder` should be closed (or ignored in `dependabot.yml`) until the registry is fixed. The proper fix is adding `real:` entries for setfit's dependencies to `src/doc_builder/mock_deps/setfit.txt` in doc-builder, after which the bump can be accepted.

- Tom Aarsen
